### PR TITLE
German locale: Display pagination.next as right single quotation mark

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,8 +10,8 @@ de:
           zero: Kein %{entry_name} gefunden
   views:
     pagination:
-      first: "« Start"
-      last: Ende »
-      next: Weiter »
+      first: "&laquo; Start"
+      last: "Ende &raquo;"
+      next: "Weiter &rsaquo;"
       previous: "&lsaquo; Zurück"
       truncate: "&hellip;"


### PR DESCRIPTION
So now it's properly displayed as:

```
« Start ‹ Zurück … Weiter › Ende »
```
